### PR TITLE
Update rtree version to 0.9.7 so it can install on macos cleanly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ rasterio==1.1.8
 requests==2.25.1
 requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1
-Rtree==0.9.4
+Rtree==0.9.7
 scikit-image==0.18.1
 scipy==1.6.0
 Shapely==1.7.1


### PR DESCRIPTION
Bump the rtree version so it cleanly installs on macos as per Toblerity/rtree/issues/193